### PR TITLE
Setting of properties & attributes using __call()

### DIFF
--- a/src/Classes/Mutator.php
+++ b/src/Classes/Mutator.php
@@ -2,14 +2,16 @@
 
 namespace BendeckDavid\GraphqlClient\Classes;
 
+use BadMethodCallException;
 use Illuminate\Support\Str;
 
 class Mutator {
-    
-    public function __get($key){
+
+    public function __get(string $key)
+    {
         return match(true){
 
-            method_exists($this, 'get'.Str::studly($key).'Attribute') => 
+            method_exists($this, 'get'.Str::studly($key).'Attribute') =>
             $this->{'get'.Str::studly($key).'Attribute'}(),
 
             array_key_exists($key, $this->attributes) =>
@@ -19,5 +21,24 @@ class Mutator {
 
         };
     }
-    
+
+    public function __call(string $method, array $arguments = []) : mixed
+    {
+        match(true) {
+
+            // Set propery, if exits, using withProperty naming
+            Str::startsWith($method, 'with') &&
+            property_exists($this, Str::camel(substr($method, 4))) =>
+                $this->{Str::camel(substr($method, 4))} = $arguments[0],
+
+            // Set attribute using withAttribute naming
+            Str::startsWith($method, 'with') =>
+                $this->variables[Str::camel(substr($method, 4))] = $arguments[0],
+
+            DEFAULT => throw new BadMethodCallException("Method [$method] does not exist.")
+
+        };
+
+        return $this;
+    }
 }


### PR DESCRIPTION
# Description

Added support for setting properties & attributes using magic `withPropertyName` or `withAttributeName` methods.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
