### PR TITLE
Add additional context to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,19 @@ return GraphQL::query($query)
 ])->get();
 ```
 
+## Context
+
+Add additional context to the request
+```php
+return GraphQL::query($query)
+->context([
+    'ssl' => [
+         "verify_peer"=>false,
+         "verify_peer_name"=>false,
+    ]
+  ])->get();
+```
+
 
 ## Author
 

--- a/src/Classes/Client.php
+++ b/src/Classes/Client.php
@@ -17,6 +17,7 @@ class Client extends Mutator {
         'Content-Type' => 'application/json',
         'User-Agent' => 'Laravel GraphQL client',
     ];
+    public Array $context = [];
 
     public function __construct(
         protected String|Null $endpoint
@@ -50,13 +51,13 @@ class Client extends Mutator {
      */
     public function getRequestAttribute()
     {
-        return stream_context_create([
+        return stream_context_create(array_merge([
             'http' => [
                 'method'  => 'POST',
                 'content' => json_encode(['query' => $this->raw_query, 'variables' => $this->variables]),
                 'header'  => $this->headers,
             ]
-        ]);
+        ], $this->context));
     }
 
 
@@ -116,6 +117,18 @@ class Client extends Mutator {
     }
 
 
+    /**
+     * Allow to append a new context info to the client
+     *
+     * @return Client
+     */
+    public function context(Array $context)
+    {
+        $this->context = $context;
+        return $this;
+    }
+
+    
     /**
      * Allow to pass multiple headers to the client
      *


### PR DESCRIPTION
# Description

Adds additional context to the get_file_content request.  My use case involved preventing ssl verify in dev environment.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
