### PR TITLE
Added `getRaw()` method to request full response

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Import GraphQL Client Facades
 use BendeckDavid\GraphqlClient\Facades\GraphQL;
 ```
 
-Basic use
+#### Basic use
 
 ```php
 return GraphQL::query('
@@ -68,7 +68,8 @@ return GraphQL::query('
 //->get('json'); //get response as json object
 ```
 
-Mutator request:
+#### Mutator Request
+
 ```php
 return GraphQL::mutator('
     insert_user(name: "David") {
@@ -98,6 +99,7 @@ return GraphQL::raw('
 ```
 
 The `variables` or `payload` to the GraphQL request can also be passed using magic methods like:
+
 ```php
 return GraphQL::raw('
     mutation($name: String) {
@@ -113,7 +115,26 @@ return GraphQL::raw('
 //->get('json');
 ```
 
-If you want to address te request to another endpoint, you can do :
+#### Raw Response
+
+You can get the raw response from the GraphQL request by using `getRaw()` method instead of `get()` in the request.
+
+```php
+return GraphQL::raw('
+    mutation($name: String) {
+        insert_user(name: $name) {
+            id
+            name
+            date_added
+        }
+    }
+')
+->with(["name" => "David"])
+->getRaw();
+//->getRaw('json');
+```
+
+If you want to address the request to another endpoint, you can do :
 
 ```php
 return GraphQL::endpoint("https://api.spacex.land/graphql/")
@@ -130,7 +151,6 @@ return GraphQL::endpoint("https://api.spacex.land/graphql/")
 ')->get();
 //->get('json');
 ```
-
 
 ## Headers
 

--- a/src/Classes/Client.php
+++ b/src/Classes/Client.php
@@ -221,15 +221,17 @@ class Client extends Mutator {
      *
      * @return array
      */
-    public function makeRequest(string $format)
+    public function makeRequest(string $format, bool $rawResponse = false)
     {
         try {
             $result = file_get_contents($this->endpoint, false, $this->request);
             if ($format == Format::JSON) {
                 $response = json_decode($result, false);
+                if ($rawResponse) return $response;
                 return $response->data;
             } else {
                 $response = json_decode($result, true);
+                if ($rawResponse) return $response;                
                 return Arr::get($response, "data");
             }
 
@@ -245,9 +247,20 @@ class Client extends Mutator {
      * 
      * @return array by default
      */
-    public function get(string $format=Format::ARRAY)
+    public function get(string $format = Format::ARRAY)
     {
         return $this->makeRequest($format);
+    }
+
+    /**
+     * Return raw response
+     * @param $format String (array|json) define return format, array by default
+     * 
+     * @return array by default
+     */
+    public function getRaw(string $format = Format::ARRAY)
+    {
+        return $this->makeRequest($format, true);
     }
 
 }


### PR DESCRIPTION
# Description

Added new method `getRaw()` to return the full response body instead of scoping it to `data` only.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
