### PR TITLE
Update Client.php

### DIFF
--- a/src/Classes/Client.php
+++ b/src/Classes/Client.php
@@ -19,6 +19,7 @@ class Client extends Mutator {
         'User-Agent' => 'Laravel GraphQL client',
     ];
     public Array $context = [];
+    protected bool $ignoreErrors = false ;
 
     public function __construct(
         protected String|Null $endpoint
@@ -52,11 +53,16 @@ class Client extends Mutator {
      */
     public function getRequestAttribute()
     {
+        $content = ['query' => $this->raw_query];
+        if (!empty($this->variables)) {
+            $content['variables'] = $this->variables;
+        }
         return stream_context_create(array_merge([
             'http' => [
                 'method'  => 'POST',
-                'content' => json_encode(['query' => $this->raw_query, 'variables' => $this->variables], JSON_NUMERIC_CHECK),
+                'content' => json_encode($content, JSON_NUMERIC_CHECK),
                 'header'  => $this->headers,
+                'ignore_errors' => $this->ignoreErrors
             ]
         ], $this->context));
     }


### PR DESCRIPTION
Make it compatible to HyGraph Graphql API

# Description

I need to add a new parameter to the stream context to get the error content from the response body of the HyGraph api.
Also change to do not sent the variables parameter when its empty.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
