### PR TITLE
Disable numeric check

### DIFF
--- a/src/Classes/Client.php
+++ b/src/Classes/Client.php
@@ -8,7 +8,8 @@ use BendeckDavid\GraphqlClient\Enums\Format;
 use BendeckDavid\GraphqlClient\Enums\Request;
 use BendeckDavid\GraphqlClient\Classes\Mutator;
 
-class Client extends Mutator {
+class Client extends Mutator
+{
 
     private string $query;
     public string $queryType;
@@ -22,10 +23,7 @@ class Client extends Mutator {
 
     public function __construct(
         protected string|null $endpoint
-    )
-    {
-
-    }
+    ) {}
 
     /**
      * Generate the Graphql query in raw format
@@ -34,7 +32,7 @@ class Client extends Mutator {
      */
     public function getRawQueryAttribute()
     {
-        $content = match($this->queryType){
+        $content = match ($this->queryType) {
             Request::RAW => $this->query,
             DEFAULT => "{$this->queryType} {{$this->query}}"
         };
@@ -77,8 +75,11 @@ class Client extends Mutator {
 
         // fill Authentication header
         $authToken = isset($this->token) ? $this->token : config('graphqlclient.auth_credentials');
-        data_fill($this->rawHeaders, config('graphqlclient.auth_header'),
-            config('graphqlclient.auth_schemes')[$auth_scheme].$authToken);
+        data_fill(
+            $this->rawHeaders,
+            config('graphqlclient.auth_header'),
+            config('graphqlclient.auth_schemes')[$auth_scheme] . $authToken
+        );
     }
 
 
@@ -90,7 +91,7 @@ class Client extends Mutator {
     public function getHeadersAttribute()
     {
         // Include Authentication
-        if(config('graphqlclient.auth_credentials') || isset($this->token)) {
+        if (config('graphqlclient.auth_credentials') || isset($this->token)) {
             $this->includeAuthentication();
         }
 
@@ -225,16 +226,23 @@ class Client extends Mutator {
     {
         try {
             $result = file_get_contents($this->endpoint, false, $this->request);
+
             if ($format == Format::JSON) {
                 $response = json_decode($result, false);
                 if ($rawResponse) return $response;
-                return $response->data;
+                $data = $response->data;
             } else {
                 $response = json_decode($result, true);
                 if ($rawResponse) return $response;
-                return Arr::get($response, "data");
+                $data = Arr::get($response, 'data');
             }
 
+            // Check if the response is valid
+            if (!$data) {
+                throw new Exception('Invalid response from server: ' . $result);
+            }
+
+            return $data;
         } catch (\Throwable $th) {
             throw $th;
         }
@@ -262,5 +270,4 @@ class Client extends Mutator {
     {
         return $this->makeRequest($format, true);
     }
-
 }

--- a/src/Classes/Client.php
+++ b/src/Classes/Client.php
@@ -20,6 +20,7 @@ class Client extends Mutator
         'User-Agent' => 'Laravel GraphQL client',
     ];
     public array $context = [];
+    private $shouldUseNumericCheck = true;
 
     public function __construct(
         protected string|null $endpoint
@@ -42,6 +43,16 @@ class Client extends Mutator
         GRAPHQL;
     }
 
+    /**
+     * Disable Numeric Check
+     * 
+     */
+    public function disableNumericCheck(): self
+    {
+        $this->shouldUseNumericCheck = false;
+
+        return $this;
+    }
 
     /**
      * Build the HTTP request
@@ -53,12 +64,22 @@ class Client extends Mutator
         return stream_context_create(array_merge([
             'http' => [
                 'method'  => 'POST',
-                'content' => json_encode(['query' => $this->raw_query, 'variables' => $this->variables], JSON_NUMERIC_CHECK),
+                'content' => $this->buildJsonContent(),
                 'header'  => $this->headers,
             ]
         ], $this->context));
     }
 
+    /**
+     * Json Content
+     *
+     */
+    private function buildJsonContent(): string
+    {
+        $options = $this->shouldUseNumericCheck ? JSON_NUMERIC_CHECK : 0;
+
+        return json_encode(['query' => $this->raw_query, 'variables' => $this->variables], $options);
+    }
 
     /**
      * Include authentication headers
@@ -81,7 +102,6 @@ class Client extends Mutator
             config('graphqlclient.auth_schemes')[$auth_scheme] . $authToken
         );
     }
-
 
     /**
      * Return Client headers formatted


### PR DESCRIPTION
I want to share a use case that I believe many developers might encounter. In some scenarios, we deal with fields like invoice numbers that can take different formats. For example:

An invoice number might be INV-9876, which is clearly a string.
Another invoice could lack the prefix and be just 9876.
When using JSON_NUMERIC_CHECK, the latter gets converted into an integer, causing issues because the field is defined as a string in GraphQL. This mismatch creates significant problems when interacting with GraphQL APIs.

To address this, I've added functionality to make JSON_NUMERIC_CHECK optional. This allows developers to enable or disable this behavior depending on their specific needs, ensuring better compatibility with GraphQL type definitions.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update